### PR TITLE
Remove prototype mismatch ($) vs none during make test.

### DIFF
--- a/lib/Mail/DMARC/Iterator.pm
+++ b/lib/Mail/DMARC/Iterator.pm
@@ -52,7 +52,7 @@ sub import {
 
 
 # defined at the end, based on the public suffix module we have installed
-sub organizational_domain($);
+sub organizational_domain;
 
 sub new {
     my ($class,%args) = @_;


### PR DESCRIPTION
The warning during make test was noticed and fixed by Giovanni Bechis while
reviewing the import into the OpenBSD ports tree.